### PR TITLE
Add docker-compose for local Postgres development

### DIFF
--- a/Dockerfile.dev.postgres
+++ b/Dockerfile.dev.postgres
@@ -1,0 +1,10 @@
+# Dockerfile for local Postgres development
+FROM postgres:15-alpine
+
+# Set environment variables for default user and database (override in docker-compose or CLI)
+ENV POSTGRES_USER=postgres
+ENV POSTGRES_PASSWORD=postgres
+ENV POSTGRES_DB=zapdb
+
+# Expose default Postgres port
+EXPOSE 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  postgres:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev.postgres
+    container_name: zapslot-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: zapdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Add docker-compose.yml and Dockerfile.dev.postgres for easy local Postgres setup. Closes #7.